### PR TITLE
Remove installing flathub.json

### DIFF
--- a/org.freedesktop.appstream.cli.yaml
+++ b/org.freedesktop.appstream.cli.yaml
@@ -62,11 +62,3 @@ modules:
   - type: git
     url: https://github.com/ximion/appstream.git
     tag: v1.0.2
-
-- name: flathub-json
-  buildsystem: simple
-  build-commands:
-    - install -Dm644 flathub.json /app/flathub.json
-  sources:
-  - type: file
-    path: flathub.json


### PR DESCRIPTION
Linter now auto skips checks that matter for console applications